### PR TITLE
Added Number Return Type to fibonacci()

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n) : number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
### Description
In fib.ts the fibonacci function did not have a return type that was specified. Issue #1 
### Type of Changes
I added `number` as the expected return type for fibonnaci(). 
### Testing
This was tested by running both `npm run test` and `npm run lint` and both tests passed. 
![image](https://github.com/anguyen644/assignment-1/assets/93550993/861c3ba0-d781-45f4-b5a8-f1179a1bae48)
