### PR TITLE
Added Return Type and Parameter Type to fibonacci()

### DIFF
--- a/src/fib.ts
+++ b/src/fib.ts
@@ -1,5 +1,5 @@
 // util function that computes the fibonacci numbers
-export default function fibonacci(n) {
+export default function fibonacci(n : number) : number {
   if (n < 0) {
     return -1;
   } else if (n == 0) {


### PR DESCRIPTION
### Description
In fib.ts the fibonacci function did not have type specification in the parameter and did not have a type specification for the return either. Issue #1 
### Type of Changes
I added `number` as the parameter typing and return type.
### Testing
This was tested by running both `npm run test` and `npm run lint` and both tests passed. 
![image](https://github.com/anguyen644/assignment-1/assets/93550993/7566bdab-417c-47de-90bd-d360ea3789ec)
