### PR TITLE
Added Imports and Type Declarations to fibRoute.ts

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,8 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
-
-export default (req, res) => {
+import { Request, Response } from 'express';
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
### Description
In fibRoute.ts there is no type specification for `req` and `res`. Issue #2  
### Type of Changes
I imported `Express` for `Request` and `Response` types and added it to specify the type for `req` and `res`.
### Testing
This was tested by running both `npm run test` and `npm run lint` and both tests passed.
![image](https://github.com/anguyen644/assignment-1/assets/93550993/545e0e4b-eef0-421d-b6e8-0ab2499501b3)
